### PR TITLE
Fix default export

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.m.js",
   "exports": {
     "require": "./dist/index.js",
-    "default": "./dist/index.modern.js"
+    "default": "./dist/index.modern.mjs"
   },
   "files": [
     "dist"


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
The value of `exports.default` in `package.json` has been fixed to `./dist/index.modern.mjs`.

**Which issue (if any) does this pull request address?**
In my case, I was noticed by the following esbuild error message:
```
  The module "./dist/index.modern.js" was not found on the file system:

    node_modules/default-composer/package.json:10:15:
      10 │     "default": "./dist/index.modern.js"
         ╵                ~~~~~~~~~~~~~~~~~~~~~~~~
```

**Is there anything you'd like reviewers to focus on?**
