### PR TITLE
Handle only own keys

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -35,6 +35,7 @@ describe("defaultComposer", () => {
       },
       emails: ["contact@aralroca.com"],
       hobbies: ["programming"],
+      toString: "I am Aral",
     };
 
     const originalObject = {
@@ -47,6 +48,7 @@ describe("defaultComposer", () => {
         zip: "54321",
       },
       hobbies: ["parkour", "computer science", "books", "nature"],
+      constructor: null,
     };
 
     const expected = {
@@ -64,6 +66,8 @@ describe("defaultComposer", () => {
         zip: "54321",
       },
       hobbies: ["parkour", "computer science", "books", "nature"],
+      toString: "I am Aral",
+      constructor: null,
     };
 
     expect(defaultComposer<User>(defaults, originalObject)).toEqual(expected);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -16,6 +16,8 @@ type User = {
   address: Address;
   hobbies: string[];
   emails: string[];
+  toString: string;
+  constructor: string | null;
 };
 
 describe("defaultComposer", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,8 +30,8 @@ function compose<T>(defaults: Partial<T>, obj: Partial<T>): Partial<T> {
 
   for (let key of allKeys) {
     const defaultsValue = defaults[key];
-    const originalObjectValue = obj[key];
-    const hasDefault = key in defaults;
+    const originalObjectValue = hasOwn(obj, key) ? obj[key] : undefined;
+    const hasDefault = hasOwn(defaults, key);
     const checkOptions = { key, value: originalObjectValue };
     const defaultableValue = checkDefaultableValue(checkOptions);
     const defaultableValueFromConfig =
@@ -70,4 +70,11 @@ function checkDefaultableValue({ value }: { value: unknown }): boolean {
     value === null ||
     isEmptyObjectOrArray(value)
   );
+}
+
+function hasOwn<T extends PropertyKey>(
+  obj: Partial<Record<T, unknown>>,
+  key: unknown
+): key is T {
+  return Object.prototype.hasOwnProperty.call(obj, key);
 }


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Only consider keys that are an own property of the object and ignore inherited properties. With a simple object, there could be a conflict when a property also exists on `Object.prototype` like `toString`. This applies both to defaults as well as the composed object as shown in the tests.

**Which issue (if any) does this pull request address?**
An inconsistency with how the spread operator works:

```ts
({ ...{ toString: 1 }, ...{ a: 3 } })
// -> { toString: 1, a: 3 }
```

**Is there anything you'd like reviewers to focus on?**
1. In the test, I add a property that does not exist on the defaults and has a value set to `null`. This not only tests the use case for this fix but also shows what happens when there is no default.
2. The proper modern way would be to use (Object.hasOwn)[https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn] which does not have that wide support. Plus, there were issues with TypeScript target.